### PR TITLE
delete reactive messages before removing them from cache & db

### DIFF
--- a/src/main/java/de/anteiku/kittybot/commands/music/PlayCommand.java
+++ b/src/main/java/de/anteiku/kittybot/commands/music/PlayCommand.java
@@ -79,7 +79,6 @@ public class PlayCommand extends ACommand{
 				//ctx.getChannel().editMessageById(ctx.getMessageId(), PlayCommand.buildMusicControlMessage(musicPlayer).build()).queue();
 			}
 			else if(emoji.equals(Emotes.X.get())){
-				event.getChannel().deleteMessageById(event.getMessageId()).queue();// TODO deleting the message is bad :)
 				Cache.destroyMusicPlayer(event.getGuild(), event.getMessageId());
 			}
 			musicPlayer.updateMusicControlMessage(event.getChannel());

--- a/src/main/java/de/anteiku/kittybot/database/Database.java
+++ b/src/main/java/de/anteiku/kittybot/database/Database.java
@@ -359,7 +359,7 @@ public class Database{
 			stmt.setString(2, guildId);
 			var result = SQL.query(stmt);
 			if(result != null && result.next()){
-				return new ReactiveMessage(result.getString("message_id"), result.getString("user_id"), result.getString("command_id"), result.getString("command"), result.getString("allowed"));
+				return new ReactiveMessage(result.getString("channel_id"), result.getString("message_id"), result.getString("user_id"), result.getString("command_id"), result.getString("command"), result.getString("allowed"));
 			}
 		}
 		catch(SQLException e){
@@ -368,15 +368,16 @@ public class Database{
 		return null;
 	}
 
-	public static boolean addReactiveMessage(String guildId, String userId, String messageId, String commandId, String command, String allowed){
-		var query = "INSERT INTO reactive_messages (message_id, command_id, user_id, guild_id, command, allowed) VALUES (?, ?, ?, ?, ?, ?)";
+	public static boolean addReactiveMessage(String guildId, String userId, String channelId, String messageId, String commandId, String command, String allowed){
+		var query = "INSERT INTO reactive_messages (channel_id, message_id, command_id, user_id, guild_id, command, allowed) VALUES (?, ?, ?, ?, ?, ?, ?)";
 		try(var con = SQL.getConnection(); var stmt = con.prepareStatement(query)){
-			stmt.setString(1, messageId);
-			stmt.setString(2, commandId);
-			stmt.setString(3, userId);
-			stmt.setString(4, guildId);
-			stmt.setString(5, command);
-			stmt.setString(6, allowed);
+			stmt.setString(1, channelId);
+			stmt.setString(2, messageId);
+			stmt.setString(3, commandId);
+			stmt.setString(4, userId);
+			stmt.setString(5, guildId);
+			stmt.setString(6, command);
+			stmt.setString(7, allowed);
 			return SQL.execute(stmt);
 		}
 		catch(SQLException e){

--- a/src/main/java/de/anteiku/kittybot/objects/Cache.java
+++ b/src/main/java/de/anteiku/kittybot/objects/Cache.java
@@ -141,7 +141,7 @@ public class Cache{
 	}
 
 	public static void addReactiveMessage(CommandContext ctx, Message message, ACommand cmd, String allowed){
-		REACTIVE_MESSAGES.put(message.getId(), new ReactiveMessage(ctx.getMessage().getId(), ctx.getUser().getId(), ctx.getChannel().getId(), message.getId(), cmd.command, allowed));
+		REACTIVE_MESSAGES.put(message.getId(), new ReactiveMessage(ctx.getChannel().getId(), ctx.getMessage().getId(), ctx.getUser().getId(), message.getId(), cmd.command, allowed));
 		Database.addReactiveMessage(ctx.getGuild().getId(), ctx.getUser().getId(), ctx.getChannel().getId(), message.getId(), ctx.getMessage().getId(), cmd.command, allowed);
 	}
 

--- a/src/main/java/de/anteiku/kittybot/objects/Cache.java
+++ b/src/main/java/de/anteiku/kittybot/objects/Cache.java
@@ -135,13 +135,14 @@ public class Cache{
 	// Reactive Messages Cache
 
 	public static void removeReactiveMessage(Guild guild, String messageId){
+		guild.getTextChannelById(REACTIVE_MESSAGES.get(messageId).channelId).deleteMessageById(messageId).queue();
 		REACTIVE_MESSAGES.remove(messageId);
 		Database.removeReactiveMessage(guild.getId(), messageId);
 	}
 
 	public static void addReactiveMessage(CommandContext ctx, Message message, ACommand cmd, String allowed){
-		REACTIVE_MESSAGES.put(message.getId(), new ReactiveMessage(ctx.getMessage().getId(), ctx.getUser().getId(), message.getId(), cmd.command, allowed));
-		Database.addReactiveMessage(ctx.getGuild().getId(), ctx.getUser().getId(), message.getId(), ctx.getMessage().getId(), cmd.command, allowed);
+		REACTIVE_MESSAGES.put(message.getId(), new ReactiveMessage(ctx.getMessage().getId(), ctx.getUser().getId(), ctx.getChannel().getId(), message.getId(), cmd.command, allowed));
+		Database.addReactiveMessage(ctx.getGuild().getId(), ctx.getUser().getId(), ctx.getChannel().getId(), message.getId(), ctx.getMessage().getId(), cmd.command, allowed);
 	}
 
 	public static ReactiveMessage getReactiveMessage(Guild guild, String messageId){

--- a/src/main/java/de/anteiku/kittybot/objects/ReactiveMessage.java
+++ b/src/main/java/de/anteiku/kittybot/objects/ReactiveMessage.java
@@ -2,9 +2,10 @@ package de.anteiku.kittybot.objects;
 
 public class ReactiveMessage{
 
-	public String messageId, userId, commandId, command, allowed;
+	public String channelId, messageId, userId, commandId, command, allowed;
 
-	public ReactiveMessage(String messageId, String userId, String commandId, String command, String allowed){
+	public ReactiveMessage(String channelId, String messageId, String userId, String commandId, String command, String allowed){
+		this.channelId = channelId;
 		this.messageId = messageId;
 		this.userId = userId;
 		this.commandId = commandId;

--- a/src/main/resources/sql_tables/reactive_messages.sql
+++ b/src/main/resources/sql_tables/reactive_messages.sql
@@ -1,4 +1,5 @@
 CREATE TABLE IF NOT EXISTS reactive_messages(
+  channel_id varchar(18) NOT NULL,
   message_id varchar(18) NOT NULL,
   user_id    varchar(18) NOT NULL,
   guild_id   varchar(18) NOT NULL,


### PR DESCRIPTION
as we disconnect 5 minutes after the last user leaves and nobody connects back before the timeout, we should also consider deleting the actual reactive message so it doesn't stay in the chat as it's neither necessary nor reactive anymore

this feature will need adding a db row `channel_id`