### PR TITLE
Dependencies (#459)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'java'
     id 'application'
-    id 'com.github.johnrengelman.shadow' version '7.0.0'
+    id 'com.github.johnrengelman.shadow' version '7.1.0'
     id 'nu.studer.jooq' version '6.0.1'
 }
 
@@ -17,11 +17,11 @@ repositories {
 
 dependencies {
     // discord/jda related
-    implementation('net.dv8tion:JDA:4.3.0_323') {
+    implementation('net.dv8tion:JDA:4.3.0_339') {
         exclude group: 'club.minnced', module: 'opus-java'
     }
     implementation 'com.jagrosh:jda-utilities:3.0.5'
-    implementation 'club.minnced:discord-webhooks:0.5.8'
+    implementation 'club.minnced:discord-webhooks:0.7.2'
     implementation 'dev.mlnr:BotListHandler-jda:2.0.0_11'
 
     // audio
@@ -33,13 +33,13 @@ dependencies {
 
     // database
     implementation 'com.zaxxer:HikariCP:5.0.0'
-    implementation 'org.jooq:jooq:3.15.2'
-    implementation 'org.postgresql:postgresql:42.2.23'
-    jooqGenerator 'org.postgresql:postgresql:42.2.23'
+    implementation 'org.jooq:jooq:3.15.4'
+    implementation 'org.postgresql:postgresql:42.3.0'
+    jooqGenerator 'org.postgresql:postgresql:42.3.0'
 
     // logging
     implementation 'ch.qos.logback:logback-classic:1.3.0-alpha10'
-    implementation 'io.sentry:sentry-logback:5.1.2'
+    implementation 'io.sentry:sentry-logback:5.2.4'
 
     // eval
     implementation 'org.codehaus.groovy:groovy-jsr223:3.0.9'
@@ -55,10 +55,10 @@ dependencies {
     implementation 'io.prometheus:simpleclient_httpserver:0.12.0'
 
     // other
-    implementation 'io.javalin:javalin:3.13.11'
-    implementation 'io.github.classgraph:classgraph:4.8.115'
-    implementation 'com.github.ben-manes.caffeine:caffeine:3.0.3'
-    implementation 'com.squareup.okhttp3:okhttp:4.9.1'
+    implementation 'io.javalin:javalin:4.1.1'
+    implementation 'io.github.classgraph:classgraph:4.8.129'
+    implementation 'com.github.ben-manes.caffeine:caffeine:3.0.4'
+    implementation 'com.squareup.okhttp3:okhttp:4.9.2'
 }
 
 jooq {


### PR DESCRIPTION
* Bump JDA from 4.3.0_298 to 4.3.0_299

* Bump logback-classic from 1.3.0-alpha5 to 1.3.0-alpha6

* Bump discord-webhooks from 0.5.7 to 0.5.8

* Bump JDA from 4.3.0_299 to 4.3.0_300

* Bump JDA from 4.3.0_300 to 4.3.0_301

* Bump JDA from 4.3.0_301 to 4.3.0_303

* Bump JDA from 4.3.0_303 to 4.3.0_304

* Bump classgraph from 4.8.110 to 4.8.111

* Bump JDA from 4.3.0_304 to 4.3.0_305

* Bump JDA from 4.3.0_305 to 4.3.0_306

* Bump JDA from 4.3.0_306 to 4.3.0_307

* Bump classgraph from 4.8.111 to 4.8.112

* Bump logback-classic from 1.3.0-alpha6 to 1.3.0-alpha7

* Bump classgraph from 4.8.112 to 4.8.113

* Bump logback-classic from 1.3.0-alpha7 to 1.3.0-alpha9

* Bump JDA from 4.3.0_307 to 4.3.0_309

* Bump classgraph from 4.8.113 to 4.8.114

* Bump classgraph from 4.8.114 to 4.8.115

* Bump sentry-logback from 5.0.1 to 5.1.0

* Bump JDA from 4.3.0_309 to 4.3.0_310

* Bump sentry-logback from 5.1.0 to 5.1.1

* Bump nu.studer.jooq from 6.0 to 6.0.1

* Bump javalin from 3.13.10 to 3.13.11

* Bump logback-classic from 1.3.0-alpha9 to 1.3.0-alpha10

* Bump sentry-logback from 5.1.1 to 5.1.2

* Bump jooq from 3.15.1 to 3.15.2

* Bump simpleclient_hotspot from 0.11.0 to 0.12.0

* Bump simpleclient from 0.11.0 to 0.12.0

* Bump JDA from 4.3.0_310 to 4.3.0_313

* Bump simpleclient_httpserver from 0.11.0 to 0.12.0

* bump BotListHandler

* bump jooq

* Bump JDA from 4.3.0_313 to 4.3.0_314

* Bump JDA from 4.3.0_314 to 4.3.0_315

* Bump JDA from 4.3.0_315 to 4.3.0_323

* Bump groovy-jsr223 from 3.0.8 to 3.0.9

* Bump JDA from 4.3.0_323 to 4.3.0_324

* Bump classgraph from 4.8.115 to 4.8.116

* Bump caffeine from 3.0.3 to 3.0.4

* Bump javalin from 3.13.11 to 4.0.0

* Bump JDA from 4.3.0_324 to 4.3.0_327

* Bump jooq from 3.15.2 to 3.15.3

* Bump JDA from 4.3.0_327 to 4.3.0_330

* Bump sentry-logback from 5.1.2 to 5.2.0

* Bump JDA from 4.3.0_330 to 4.3.0_331

* Bump postgresql from 42.2.23 to 42.2.24

* Bump javalin from 4.0.0 to 4.0.1

* Bump classgraph from 4.8.116 to 4.8.117

* Bump okhttp from 4.9.1 to 4.9.2

* Bump classgraph from 4.8.117 to 4.8.121

* Bump discord-webhooks from 0.5.8 to 0.7.2

* Bump JDA from 4.3.0_331 to 4.3.0_333

* Bump javalin from 4.0.1 to 4.1.0

* Bump classgraph from 4.8.121 to 4.8.123

* Bump sentry-logback from 5.2.0 to 5.2.1

* Bump com.github.johnrengelman.shadow from 7.0.0 to 7.1.0

* Bump classgraph from 4.8.123 to 4.8.125

* Bump javalin from 4.1.0 to 4.1.1

* Bump JDA from 4.3.0_333 to 4.3.0_334

* Bump classgraph from 4.8.125 to 4.8.126

* Bump sentry-logback from 5.2.1 to 5.2.2

* Bump classgraph from 4.8.126 to 4.8.128

* Bump sentry-logback from 5.2.2 to 5.2.3

* Bump sentry-logback from 5.2.3 to 5.2.4

* Bump postgresql from 42.2.24 to 42.3.0

* Bump JDA from 4.3.0_334 to 4.3.0_335

* Bump JDA from 4.3.0_335 to 4.3.0_339

* Bump classgraph from 4.8.128 to 4.8.129

* Bump jooq from 3.15.3 to 3.15.4

Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
Co-authored-by: caneleex <git@mlnr.dev>